### PR TITLE
Fix newline comment continuation behaviour

### DIFF
--- a/lib/jsdoc.js
+++ b/lib/jsdoc.js
@@ -2,7 +2,8 @@
 
 var commentator = require('./commentator'),
     leadingWhitespace = /^(\s+)?/, // Regex to pull out any leading whitespaces
-    blockComment = /^((\s+\/?\*)|(\/?\*))/, // Matches zero to many white spaces followe dy * or /*
+    firstBlockComment = /^\s+\/\*[^\/]/, // Matches zero to many white spaces followed by /*, not followed by /
+    blockComment = /^\s+\*[^\/]/, // Matches zero to many white spaces followed by *, not followed by /
     lineComment = /^((\s+\/\/)|(\/\/))/;
 
 /**
@@ -39,22 +40,34 @@ module.exports = {
             ev.command('editor:newline', function () {
                 var editor = atom.workspace.activePaneItem,
                     currentPosition = editor.getCursorBufferPosition(),
-                    previousRow = currentPosition.row - 1,
                     previousLineText;
+
+                // Abort if user is not actually editing comment
+                // (positioned at begin of line)
+                // TODO: improve this test by checking actual column of comment
+                if (currentPosition.col == 0) return;
 
                 // Get the previous line and check to see if its a comment then move the cursor back and add
                 // a new line.
-                editor.setCursorBufferPosition([previousRow, 0]);
-                editor.selectToEndOfLine();
-                previousLineText = editor.getSelectedText();
+                previousLineText = getLine(editor);
 
                 editor.setCursorBufferPosition(currentPosition);
 
                 // If the previous line is a comment, lets assume we want to continue comment.
-                if (previousLineText.match(blockComment)) {
-                    editor.insertText('* ');
+                if (previousLineText.match(firstBlockComment)) {
+                    // setTimeout delegates insertion to after editor has actually
+                    // moved cursor at next line
+                    setTimeout(function() {
+                        editor.insertText(' * ');
+                    });
+                } else if (previousLineText.match(blockComment)) {
+                    setTimeout(function() {
+                        editor.insertText('* ');
+                    });
                 } else if (previousLineText.match(lineComment)) {
-                    editor.insertText('// ');
+                    setTimeout(function() {
+                        editor.insertText('// ');
+                    });
                 }
             });
         });


### PR DESCRIPTION
Here are a few fixes/improvements :

1) I noticed that Atom now seem to add the newline **after** firing the `editor:newline` event. Not sure if its related to my platform (OSX yosemite)

So instead of having this : 

```
// Commenting blablabla then newline
// <-- cursor now here
```

Here is the current behaviour :

```
// Commenting blablabla then newline// <-- useless comment added here
<-- cursor now here, uncommented
```

I fixed this by wrapping the comments characters insertion in a`setTimeout`, and removing the currentRow - 1 because when called, the function is still on the previous row

2) Add a firstBlockComment regexp to deal with first comment line

Without fix : 

```
/**
* <-- missing one leading space
```

3) Add a `[^\/]` to the blockComent regexps so when pressing enter after an already-closed comment, it does not continue

Without fix :

```
/**
 * Comment 
 */ <--- pressing enter here
 * <-- comment unexpectedly continued
```

4) Used `getLine` function to optimize code
