### PR TITLE
Add jsblock to the workspace context menu

### DIFF
--- a/menus/jsdoc.cson
+++ b/menus/jsdoc.cson
@@ -1,0 +1,4 @@
+'context-menu':
+  'atom-workspace atom-text-editor:not(.mini)': [
+    {label: 'Add a JSDoc comment', command: 'jsdoc:block'}
+  ]


### PR DESCRIPTION
I guess it would be beneficial for user who actively use the mouse during their work. It also allows to use package out of the box (i.e. I had to remap ctrl+shit+d combination because it duplicates line by default)