### PR TITLE
Fix deprecation warnings so that it can be used in the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jsdoc package
 
 Atom package for quick jsdoc comment generation.
+Forked from [Atom JS Doc by Craig Offutt](https://github.com/coffutt/atom-jsdoc)
 
 ## Usage
 

--- a/lib/jsdoc.js
+++ b/lib/jsdoc.js
@@ -13,7 +13,7 @@ var commentator = require('./commentator'),
  * @return {String}        The string at the current cursor line
  */
 function getLine (editor) {
-    editor.moveCursorToBeginningOfLine();
+    editor.moveToBeginningOfLine();
     editor.selectToEndOfLine();
     return editor.getSelectedText();
 }
@@ -46,7 +46,7 @@ function continueComments (editor) {
  * @return undefined
  */
 function writeBlock () {
-    var editor = atom.workspace.activePaneItem,
+    var editor = atom.workspace.getActivePaneItem(),
         initialCursorPosition = editor.getCursorBufferPosition(),
         commentStart = initialCursorPosition.row + 1,
         commentEnd,
@@ -59,7 +59,7 @@ function writeBlock () {
 
     // Get the text on the current line and the one below it.
     thisLine = getLine(editor);
-    editor.moveCursorDown();
+    editor.moveDown();
     nextLine = getLine(editor);
     indent = nextLine.match(leadingWhitespace)[1] || thisLine.match(leadingWhitespace)[1] || '';
 
@@ -69,7 +69,7 @@ function writeBlock () {
     if (thisLine.trim() !== '') {
         editor.setCursorBufferPosition(initialCursorPosition);
         editor.insertNewlineBelow();
-        editor.moveCursorDown();
+        editor.moveDown();
         nextLine = getLine(editor);
     }
 
@@ -81,14 +81,14 @@ function writeBlock () {
     // Move the cursor to the beginning of where we'll start writing our comment.
     editor.setCursorBufferPosition([initialCursorPosition.row, 0]);
     editor.insertNewlineBelow();
-    editor.moveCursorToBeginningOfLine();
+    editor.moveToBeginningOfLine();
 
     // Write out each of the comment lines one by one
     commentLines.forEach(function (line, index) {
         editor.insertText(indent + line);
         if (index !== commentLines.length - 1) {
             editor.insertNewlineBelow();
-            editor.moveCursorToBeginningOfLine();
+            editor.moveToBeginningOfLine();
         }
     });
 
@@ -98,10 +98,10 @@ function writeBlock () {
     // can just start typing their comment. If it's a function comment, we'll highlight the description
     // placeholder in the main section of the comment for easy editing.
     if (commentType === 'EMPTY') {
-        editor.moveCursorUp();
+        editor.moveUp();
     } else {
         editor.setCursorBufferPosition([initialCursorPosition.row + 2, 0]);
-        editor.moveCursorToEndOfLine();
+        editor.moveToEndOfLine();
         editor.selectToPreviousWordBoundary();
 
         // We're looking for the 'description' text in the main comment body so that we can
@@ -124,7 +124,9 @@ module.exports = {
         atom.commands.add('atom-text-editor', {
             'jsdoc:block': writeBlock,
             'editor:newline': function(event) {
-                continueComments(this.getModel());
+                var editor = atom.workspace.getActiveTextEditor();
+                console.log("Editor", editor);
+                continueComments(editor);
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-easy-jsdoc",
   "main": "./lib/jsdoc",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "JSDoc style comments for javascript development",
   "activationCommands": {
     "atom-workspace": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-easy-jsdoc",
   "main": "./lib/jsdoc",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "JSDoc style comments for javascript development",
   "activationCommands": {
     "atom-workspace": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsdoc",
   "main": "./lib/jsdoc",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "JSDoc style comments for javascript development",
   "activationCommands": {
     "atom-workspace": [
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/craig-o/atom-jsdoc"
+    "url": "https://github.com/tgandrews/atom-jsdoc"
   },
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tgandrews/atom-jsdoc"
+    "url": "https://github.com/tgandrews/atom-easy-jsdoc"
   },
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">1.0.0"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jsdoc",
+  "name": "atom-easy-jsdoc",
   "main": "./lib/jsdoc",
-  "version": "3.0.0",
+  "version": "1.0.0",
   "description": "JSDoc style comments for javascript development",
   "activationCommands": {
     "atom-workspace": [
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">1.0.0"
+    "atom": ">=1.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This fixes issues #33 #31 #29 #27 #26 #23

I used the deprecations in the source code of [version 0.211](https://github.com/atom/atom/blob/v0.211.0/src/text-editor.coffee) to work out what we should be calling.
